### PR TITLE
Fix indentation error

### DIFF
--- a/sysinfo/sysinfo.py
+++ b/sysinfo/sysinfo.py
@@ -595,7 +595,7 @@ class SysInfo(commands.Cog):
                                            p.dict['memory_percent'],
                                            ctime,
                                            p.dict['name'] or '')
-        await self._say(ctx, msg)
+                await self._say(ctx, msg)
         return
 
     @sysinfo.command()


### PR DESCRIPTION
This fixes an indentation error that caused the output of `[p]sysinfo top 0` to always be displayed twice.